### PR TITLE
CH-280: Filter out prev undefined value from cursor

### DIFF
--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -191,7 +191,7 @@ const convertNodesToEdges = (nodes, _, {
 }) => nodes.map((node) => {
   const dataValue = operateOverScalarOrArray('', orderColumn, (orderBy, index, prev) => {
     const nodeValue = node[orderBy];
-    const result = `${prev}${index ? ARRAY_DATA_SEPARATION_TOKEN : ''}${JSON.stringify(nodeValue)}`;
+    const result = `${prev !== 'undefined' ? prev : ''}${prev !== 'undefined' && index ? ARRAY_DATA_SEPARATION_TOKEN : ''}${JSON.stringify(nodeValue)}`;
     return result;
   });
 


### PR DESCRIPTION
- don't interpolate `'undefined'` to the cursor value